### PR TITLE
fix performance problem reading meta.json on startup

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -133,7 +133,7 @@ impl DiskPartition {
             });
         }
 
-        let meta_file = File::open(&meta_path)?;
+        let meta_file = std::io::BufReader::new(File::open(&meta_path)?);
         let meta: PartitionMeta = serde_json::from_reader(meta_file)?;
 
         // Memory-map the data file


### PR DESCRIPTION
serde-json will read one byte at a time, generating one syscall per byte, unless we buffer the read.

Buffering can be done simply with the std::io::BufReader.

Without this, startup time for calling StorageBuilder::build() is linear with the size of the data and was punishingly slow: 30 seconds with only 1.4MB of data in my very simple test scenario.

With the BufReader in place, startup is a much more acceptable 40ms.